### PR TITLE
m3print: fix format specifier

### DIFF
--- a/m3print.c
+++ b/m3print.c
@@ -65,7 +65,7 @@ oneline(char *f)
 			printf("%*s", w, f);
 			break;
 		case 'i':
-			printf("%*d", w, idx);
+			printf("%*ld", w, idx);
 			break;
 		case 'T':
 			printf("%*s", w, t.album);


### PR DESCRIPTION
```
m3print.c:68:21: warning: format specifies type 'int' but the argument has type 'long' [-Wformat]
                        printf("%*d", w, idx);
                                ~~~      ^~~
                                %*ld
1 warning generated.
```
